### PR TITLE
Add snippet for getting Firestore instance in cpp

### DIFF
--- a/.github/workflows/firestore-ios.yml
+++ b/.github/workflows/firestore-ios.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
         matrix:
-          destination: ['platform=iOS Simulator,OS=13.5,name=iPhone 11']
+          destination: ['platform=iOS Simulator,OS=latest,name=iPhone 11']
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/firestore/ios/firestore-snippets-cpp/AppDelegate.mm
+++ b/firestore/ios/firestore-snippets-cpp/AppDelegate.mm
@@ -33,7 +33,7 @@ using firebase::firestore::Firestore;
   // [START get_firestore_instance]
   // Make sure the call to `Create()` happens some time before you call Firestore::GetInstance().
   App::Create();
-  Firestore * db = Firestore::GetInstance();
+  Firestore* db = Firestore::GetInstance();
   // [END get_firestore_instance]
   (void)db; // suppress unused variable warning
   return YES;

--- a/firestore/ios/firestore-snippets-cpp/AppDelegate.mm
+++ b/firestore/ios/firestore-snippets-cpp/AppDelegate.mm
@@ -17,6 +17,7 @@
 #import "AppDelegate.h"
 #import <Firebase/Firebase.h>
 #include "firebase/app.h"
+#include "firebase/firestore.h"
 
 @interface AppDelegate ()
 
@@ -24,10 +25,15 @@
 
 @implementation AppDelegate
 
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [FIRApp configure];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+  // [START get_firestore_instance]
   firebase::App::Create();
+  auto db = firebase::firestore::Firestore::GetInstance();
+  // [END get_firestore_instance]
+#pragma clang diagnostic pop
   return YES;
 }
 

--- a/firestore/ios/firestore-snippets-cpp/AppDelegate.mm
+++ b/firestore/ios/firestore-snippets-cpp/AppDelegate.mm
@@ -19,6 +19,9 @@
 #include "firebase/app.h"
 #include "firebase/firestore.h"
 
+using firebase::App;
+using firebase::firestore::Firestore;
+
 @interface AppDelegate ()
 
 @end
@@ -27,13 +30,12 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [FIRApp configure];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
   // [START get_firestore_instance]
-  firebase::App::Create();
-  auto db = firebase::firestore::Firestore::GetInstance();
+  // Make sure the call to `Create()` happens some time before you call Firestore::GetInstance().
+  App::Create();
+  Firestore * db = Firestore::GetInstance();
   // [END get_firestore_instance]
-#pragma clang diagnostic pop
+  (void)db; // suppress unused variable warning
   return YES;
 }
 


### PR DESCRIPTION
@var-const GitHub won't let me add you as a reviewer (probably something teams-related), but PTAL

The snippet will eventually replace the following on devsite:

```cpp
using firebase::App;
using firebase::firestore::Firestore;
// Make sure this call happens some time before you call Firestore::GetInstance().
App::Create();
Firestore* db = Firestore::GetInstance();
```